### PR TITLE
Use text or pixel number for min_width

### DIFF
--- a/src/block.rs
+++ b/src/block.rs
@@ -20,7 +20,7 @@ pub struct Block {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub border_right: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub min_width: Option<u32>,
+    pub min_width: Option<Width>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub align: Option<Align>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -50,4 +50,11 @@ pub enum Align {
 pub enum Markup {
     Pango,
     None,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum Width {
+    Pixels(u32),
+    Text(String),
 }


### PR DESCRIPTION
Hi,

swaybar protocol allows either number or text for `min_width`. Number is treated as width in pixels. If text is given, swaybar calculate width of this text, for current font type, size etc.

I added a simple enum and use it as a type for `min_width` to use this feature.